### PR TITLE
feat: unify admin and user entry with role-based login

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,99 +1,24 @@
 import React from 'react';
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  NavLink
-} from 'react-router-dom';
-import PitchExpert from './PitchExpert';
-import TestCustomerCalls from './TestCustomerCalls';
-import HomePage from './HomePage'; // Import the new HomePage component
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import Login from './Login';
+import UserApp from './UserApp';
+import AdminApp from './admin/AdminApp';
 
 function App() {
-  const navStyle = {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: '15px 30px',
-    background: '#e0e0e0', // Contrasting color (light grey)
-    borderBottom: '2px solid #c0c0c0',
-    position: 'sticky',
-    top: 0,
-    zIndex: 1000,
-    fontFamily: '"Nunito Sans", sans-serif', // Added font
-    borderRadius: '0 0 10px 10px', // Rounded bottom corners
-  };
-
-  const navLinksContainerStyle = {
-    display: 'flex',
-    alignItems: 'center',
-  };
-
-  const linkStyle = {
-    margin: '0 15px',
-    textDecoration: 'none',
-    color: '#333', // Dark text for light background
-    fontWeight: 'bold',
-    fontSize: '18px',
-    padding: '10px 15px',
-    borderRadius: '5px',
-    transition: 'background-color 0.3s ease, color 0.3s ease',
-    fontFamily: '"Nunito Sans", sans-serif', // Added font
-  };
-
-  const activeLinkStyle = {
-    color: '#007bff', // Example: Bootstrap primary blue for active state
-    fontWeight: 'bold', // Ensure font weight remains bold or becomes bolder
-    // background: '#cce5ff', // Optional: a light background for active link
-  };
-
-  const logoStyle = {
-    height: '50px', // Adjust as needed
-  };
+  const role = localStorage.getItem('role');
 
   return (
-    <>
-      <style>{`body { font-family: 'Nunito Sans', sans-serif !important; }`}</style>
-      <Router>
-      <div>
-        <nav style={navStyle}>
-          <div style={navLinksContainerStyle}>
-            <NavLink 
-              to="/home" 
-              style={({ isActive }) => isActive ? { ...linkStyle, ...activeLinkStyle } : linkStyle}
-            >
-              Home
-            </NavLink>
-            <NavLink 
-              to="/" 
-              style={({ isActive }) => isActive ? { ...linkStyle, ...activeLinkStyle } : linkStyle}
-              end // Use 'end' prop for root path to avoid matching all child routes
-            >
-              Pitch Expert
-            </NavLink>
-            <NavLink 
-              to="/customer-calls" 
-              style={({ isActive }) => isActive ? { ...linkStyle, ...activeLinkStyle } : linkStyle}
-            >
-              Customer Calls
-            </NavLink>
-          </div>
-          <div>
-            <img src="/rupeek-logo.png" alt="Rupeek Logo" style={logoStyle} />
-          </div>
-          <div style={{ width: 'calc(33.33% - 30px)' }}>{/* Placeholder for right alignment if needed, or to balance flex */}</div>
-        </nav>
-
-        <div style={{ paddingTop: '20px' }}>
-          <Routes>
-            <Route path="/home" element={<HomePage />} />
-            <Route path="/customer-calls" element={<TestCustomerCalls />} />
-            <Route path="/" element={<PitchExpert />} />
-          </Routes>
-        </div>
-      </div>
+    <Router>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        {role === 'admin' && <Route path="/admin/*" element={<AdminApp />} />}
+        {role === 'user' && <Route path="/*" element={<UserApp />} />}
+        <Route
+          path="*"
+          element={<Navigate to={role === 'admin' ? '/admin' : role === 'user' ? '/' : '/login'} replace />}
+        />
+      </Routes>
     </Router>
-  </>
   );
 }
 

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function Login() {
+  const [role, setRole] = useState('user');
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    localStorage.setItem('role', role);
+    navigate(role === 'admin' ? '/admin' : '/');
+  };
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', justifyContent: 'center', alignItems: 'center' }}>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <h2>Login</h2>
+        <select value={role} onChange={e => setRole(e.target.value)}>
+          <option value="user">User</option>
+          <option value="admin">Admin</option>
+        </select>
+        <button type="submit">Enter</button>
+      </form>
+    </div>
+  );
+}
+
+export default Login;
+

--- a/frontend/src/UserApp.js
+++ b/frontend/src/UserApp.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Routes, Route, NavLink } from 'react-router-dom';
+import PitchExpert from './PitchExpert';
+import TestCustomerCalls from './TestCustomerCalls';
+import HomePage from './HomePage'; // Import the new HomePage component
+
+function UserApp() {
+  const navStyle = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '15px 30px',
+    background: '#e0e0e0', // Contrasting color (light grey)
+    borderBottom: '2px solid #c0c0c0',
+    position: 'sticky',
+    top: 0,
+    zIndex: 1000,
+    fontFamily: '"Nunito Sans", sans-serif', // Added font
+    borderRadius: '0 0 10px 10px', // Rounded bottom corners
+  };
+
+  const navLinksContainerStyle = {
+    display: 'flex',
+    alignItems: 'center',
+  };
+
+  const linkStyle = {
+    margin: '0 15px',
+    textDecoration: 'none',
+    color: '#333', // Dark text for light background
+    fontWeight: 'bold',
+    fontSize: '18px',
+    padding: '10px 15px',
+    borderRadius: '5px',
+    transition: 'background-color 0.3s ease, color 0.3s ease',
+    fontFamily: '"Nunito Sans", sans-serif', // Added font
+  };
+
+  const activeLinkStyle = {
+    color: '#007bff', // Example: Bootstrap primary blue for active state
+    fontWeight: 'bold', // Ensure font weight remains bold or becomes bolder
+    // background: '#cce5ff', // Optional: a light background for active link
+  };
+
+  const logoStyle = {
+    height: '50px', // Adjust as needed
+  };
+
+  return (
+    <>
+      <style>{`body { font-family: 'Nunito Sans', sans-serif !important; }`}</style>
+      <div>
+        <nav style={navStyle}>
+          <div style={navLinksContainerStyle}>
+            <NavLink 
+              to="/home" 
+              style={({ isActive }) => isActive ? { ...linkStyle, ...activeLinkStyle } : linkStyle}
+            >
+              Home
+            </NavLink>
+            <NavLink 
+              to="/" 
+              style={({ isActive }) => isActive ? { ...linkStyle, ...activeLinkStyle } : linkStyle}
+              end // Use 'end' prop for root path to avoid matching all child routes
+            >
+              Pitch Expert
+            </NavLink>
+            <NavLink 
+              to="/customer-calls" 
+              style={({ isActive }) => isActive ? { ...linkStyle, ...activeLinkStyle } : linkStyle}
+            >
+              Customer Calls
+            </NavLink>
+          </div>
+          <div>
+            <img src="/rupeek-logo.png" alt="Rupeek Logo" style={logoStyle} />
+          </div>
+          <div style={{ width: 'calc(33.33% - 30px)' }}>{/* Placeholder for right alignment if needed, or to balance flex */}</div>
+        </nav>
+
+        <div style={{ paddingTop: '20px' }}>
+          <Routes>
+            <Route path="/home" element={<HomePage />} />
+            <Route path="/customer-calls" element={<TestCustomerCalls />} />
+            <Route path="/" element={<PitchExpert />} />
+          </Routes>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default UserApp;

--- a/frontend/src/admin/AdminApp.css
+++ b/frontend/src/admin/AdminApp.css
@@ -1,0 +1,14 @@
+/* Basic styles for the admin app can go here */
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-color: #f4f7f6;
+}
+
+.App {
+  /* Add any top-level App container styles if needed */
+}

--- a/frontend/src/admin/AdminApp.js
+++ b/frontend/src/admin/AdminApp.js
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import { Routes, Route, NavLink } from 'react-router-dom';
+import ProductManager from './ProductManager';
+// import CustomerCallManager from './components/CustomerCallManager';
+import './AdminApp.css';
+
+function AdminApp() {
+  // Inject Nunito Sans font globally
+  React.useEffect(() => {
+    document.body.style.fontFamily = "'Nunito Sans', sans-serif";
+  }, []);
+  const [products, setProducts] = useState([]);
+  const [selectedProduct, setSelectedProduct] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Styles for Navbar and NavLinks
+  const navLinkStyle = ({ isActive }) => ({
+    color: 'white',
+    textDecoration: 'none',
+    marginRight: '20px',
+    padding: '8px 12px',
+    borderRadius: '6px',
+    transition: 'background-color 0.3s ease',
+    backgroundColor: isActive ? '#e44210' : 'transparent', // Active link color from user panel
+    fontWeight: isActive ? 'bold' : 'normal',
+  });
+
+  const navBarStyle = {
+    display: 'flex',
+    justifyContent: 'space-between', // Links left, (future logout right)
+    alignItems: 'center',
+    padding: '10px 30px',
+    backgroundColor: '#4a4a4a', // Dark grey for admin distinction
+    color: 'white',
+    borderRadius: '0 0 12px 12px', // Rounded bottom corners
+    boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+    position: 'relative', // For absolute positioning of the logo
+    marginBottom: '20px', // Keep existing margin
+  };
+
+  const navLinksContainerStyle = {
+    display: 'flex',
+    alignItems: 'center',
+  };
+
+  const logoStyle = {
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    fontSize: '1.6em',
+    fontWeight: 'bold',
+    color: 'white',
+    textDecoration: 'none', // Ensure logo is not underlined if wrapped in a link
+  };
+
+  const fetchProducts = () => {
+    setLoading(true);
+    fetch('/api/products')
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return res.json();
+      })
+      .then(data => {
+        setProducts(data);
+        setError(null);
+      })
+      .catch(err => {
+        console.error("Fetch error:", err);
+        setError('Failed to load products.');
+        setProducts([]); 
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    fetchProducts();
+  }, []);
+
+  const renderContent = () => {
+    if (loading) {
+      return <p>Loading...</p>;
+    }
+    if (error) {
+      return <p style={{ color: 'red' }}>{error}</p>;
+    }
+    return (
+      <Routes>
+        <Route
+          path="/"
+          element={(
+            <ProductManager
+              products={products}
+              onChange={fetchProducts}
+              selectedProduct={selectedProduct}
+              setSelectedProduct={setSelectedProduct}
+            />
+          )}
+        />
+        {/* <Route path="/customer-call-management" element={<CustomerCallManager />} /> */}
+      </Routes>
+    );
+  };
+
+  return (
+    <div className="App">
+      <nav style={navBarStyle}>
+        <div style={navLinksContainerStyle}>
+          <NavLink to="/admin" style={navLinkStyle}>
+            Manage Products
+          </NavLink>
+          {/* <NavLink to="/admin/customer-call-management" style={navLinkStyle}>
+            Manage Call Scenarios
+          </NavLink> */}
+          {/* Future link for Customer Call Management will go here */}
+        </div>
+        <div style={logoStyle}>Pitch Expert Admin</div>
+        <div>{/* Placeholder for right-aligned items e.g., Logout button */}</div>
+      </nav>
+
+      <div style={{ padding: '0 20px' }}>
+        {renderContent()}
+      </div>
+
+    </div>
+  );
+}
+
+export default AdminApp;
+

--- a/frontend/src/admin/AudioUpload.js
+++ b/frontend/src/admin/AudioUpload.js
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+
+function AudioUpload() {
+  const [audioFile, setAudioFile] = useState(null);
+  const [tags, setTags] = useState({
+    language: 'English',
+    product: 'General',
+    audioType: 'Inquiry',
+    difficulty: 'Easy',
+    evaluationCriteria: ''
+  });
+  const [uploadStatus, setUploadStatus] = useState('');
+
+  const handleFileChange = (event) => {
+    setAudioFile(event.target.files[0]);
+    setUploadStatus('');
+  };
+
+  const handleTagChange = (event) => {
+    const { name, value } = event.target;
+    setTags(prevTags => ({ ...prevTags, [name]: value }));
+    setUploadStatus('');
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!audioFile) {
+      setUploadStatus('Please select an audio file.');
+      return;
+    }
+
+    setUploadStatus('Uploading...');
+    const formData = new FormData();
+    formData.append('audio', audioFile); // 'audio' must match multer field name
+    formData.append('language', tags.language);
+    formData.append('product', tags.product);
+    formData.append('audioType', tags.audioType);
+    formData.append('difficulty', tags.difficulty);
+    formData.append('evaluationCriteria', tags.evaluationCriteria);
+
+    try {
+      const response = await fetch('/api/admin/upload-customer-audio', {
+        method: 'POST',
+        body: formData, // No 'Content-Type' header needed; browser sets it for FormData
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        setUploadStatus(`Successfully uploaded ${audioFile.name}!`);
+        setAudioFile(null); // Clear file input
+        // Optionally reset tags or clear form
+        document.getElementById('audioFile').value = ''; // Reset file input visually
+      } else {
+        console.error('Upload failed response:', result);
+        setUploadStatus(`Upload failed: ${result.message || response.statusText}`);
+      }
+    } catch (error) {
+      console.error('Upload fetch error:', error);
+      setUploadStatus(`Upload error: ${error.message}. Check network or server.`);
+    }
+  };
+
+  // Basic inline styles for simplicity
+  const styles = {
+    container: { padding: '20px', maxWidth: '500px', margin: '20px auto', border: '1px solid #ccc', borderRadius: '8px', background: '#f9f9f9' },
+    formGroup: { marginBottom: '15px' },
+    label: { display: 'block', marginBottom: '5px', fontWeight: 'bold' },
+    input: { width: '100%', padding: '8px', boxSizing: 'border-box', border: '1px solid #ccc', borderRadius: '4px' },
+    select: { width: '100%', padding: '8px', boxSizing: 'border-box', border: '1px solid #ccc', borderRadius: '4px' },
+    button: { padding: '10px 15px', background: '#007bff', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' },
+    status: { marginTop: '15px', fontWeight: 'bold' },
+  };
+
+  return (
+    <div style={styles.container}>
+      <h2>Upload Customer Call Audio</h2>
+      <form onSubmit={handleSubmit}>
+        <div style={styles.formGroup}>
+          <label htmlFor="audioFile" style={styles.label}>Audio File:</label>
+          <input
+            type="file"
+            id="audioFile"
+            accept="audio/*"
+            onChange={handleFileChange}
+            style={styles.input}
+            required
+          />
+        </div>
+
+        <div style={styles.formGroup}>
+          <label htmlFor="language" style={styles.label}>Language:</label>
+          <select id="language" name="language" value={tags.language} onChange={handleTagChange} style={styles.select}>
+            <option value="English">English</option>
+            <option value="Hindi">Hindi</option>
+            <option value="Tamil">Tamil</option>
+            {/* Add other languages as needed */}
+          </select>
+        </div>
+
+        <div style={styles.formGroup}>
+          <label htmlFor="product" style={styles.label}>Product:</label>
+          <input
+            type="text"
+            id="product"
+            name="product"
+            value={tags.product}
+            onChange={handleTagChange}
+            placeholder="e.g., Gold Loan, Insurance" 
+            style={styles.input}
+          />
+        </div>
+
+        <div style={styles.formGroup}>
+          <label htmlFor="audioType" style={styles.label}>Audio Type:</label>
+          <select id="audioType" name="audioType" value={tags.audioType} onChange={handleTagChange} style={styles.select}>
+            <option value="Inquiry">Inquiry</option>
+            <option value="Complaint">Complaint</option>
+            <option value="Follow-up">Follow-up</option>
+            <option value="Sales Pitch">Sales Pitch</option>
+             {/* Add other types as needed */}
+          </select>
+        </div>
+
+        <div style={styles.formGroup}>
+          <label htmlFor="difficulty" style={styles.label}>Difficulty:</label>
+          <select id="difficulty" name="difficulty" value={tags.difficulty} onChange={handleTagChange} style={styles.select}>
+            <option value="Easy">Easy</option>
+            <option value="Medium">Medium</option>
+            <option value="Hard">Hard</option>
+          </select>
+        </div>
+
+        <div style={styles.formGroup}>
+          <label htmlFor="evaluationCriteria" style={styles.label}>Evaluation Criteria:</label>
+          <textarea
+            id="evaluationCriteria"
+            name="evaluationCriteria"
+            value={tags.evaluationCriteria}
+            onChange={handleTagChange}
+            placeholder="Define criteria for response evaluation"
+            style={{ ...styles.input, height: '80px' }}
+          />
+        </div>
+
+        <button type="submit" style={styles.button}>Upload Audio</button>
+      </form>
+      {uploadStatus && <p style={styles.status}>{uploadStatus}</p>}
+    </div>
+  );
+}
+
+export default AudioUpload;

--- a/frontend/src/admin/ProductManager.js
+++ b/frontend/src/admin/ProductManager.js
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from "react";
+import RubricModal from './RubricModal';
+
+export default function ProductManager({ products, onChange, selectedProduct, setSelectedProduct }) {
+  const [newProduct, setNewProduct] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState("");
+  const [activateOnAdd, setActivateOnAdd] = useState(true);
+  const [selectedRubricId, setSelectedRubricId] = useState("");
+  const [rubrics, setRubrics] = useState([]);
+  const [rubricModalOpen, setRubricModalOpen] = useState(false);
+  // State for RubricModal when editing or creating criteria
+  const [modalInitialName, setModalInitialName] = useState("");
+  const [modalInitialQualities, setModalInitialQualities] = useState([]);
+  const [modalRubricId, setModalRubricId] = useState(null);
+
+  useEffect(() => {
+    // Fetch rubrics on mount
+    fetch("/api/rubric-list")
+      .then(res => res.json())
+      .then(setRubrics);
+  }, [rubricModalOpen]); // refetch when modal closes
+
+  const handleAdd = async () => {
+    if (!newProduct.trim() || !selectedRubricId) return;
+    setAdding(true);
+    setError("");
+    try {
+      const res = await fetch("/api/products", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newProduct, rubricId: selectedRubricId, active: activateOnAdd })
+      });
+      if (!res.ok) throw new Error("Failed to add product");
+      setNewProduct("");
+      setSelectedRubricId("");
+      onChange(); // trigger reload
+    } catch (err) {
+      setError("Could not add product. Try again.");
+    }
+    setAdding(false);
+  };
+
+  // Deduplicate rubrics by name (show only unique rubric names)
+  const uniqueRubrics = Array.from(
+    new Map(rubrics.map(r => [r.name, r])).values()
+  );
+
+  return (
+    <div style={{ background: '#f0f4ff', borderRadius: 12, padding: 18, marginBottom: 30 }}>
+      <h2 style={{ marginTop: 0 }}>Product Master List</h2>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 14 }}>
+        <input
+          value={newProduct}
+          onChange={e => setNewProduct(e.target.value)}
+          placeholder="Add new product"
+          style={{ fontSize: 16, padding: 6, borderRadius: 4, border: '1px solid #ccc', flex: 2 }}
+        />
+        <select
+          value={selectedRubricId}
+          onChange={e => {
+            if (e.target.value === '__add__') {
+              // Open modal to create new criteria
+              setModalInitialName("");
+              setModalInitialQualities([]);
+              setModalRubricId(null);
+              setRubricModalOpen(true);
+            } else {
+              setSelectedRubricId(e.target.value);
+            }
+          }}
+          style={{ fontSize: 16, padding: 6, borderRadius: 4, border: '1px solid #ccc', flex: 1 }}
+        >
+          <option value="">Select pitch criteria</option>
+          {uniqueRubrics.map(r => (
+            <option key={r._id} value={r._id}>{r.name}</option>
+          ))}
+          <option value="__add__">+ Add Pitch Criteria</option>
+        </select>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 15 }}>
+          <input type="checkbox" checked={activateOnAdd} onChange={e => setActivateOnAdd(e.target.checked)} />
+          Activate now?
+        </label>
+        <button onClick={handleAdd} disabled={adding || !newProduct.trim() || !selectedRubricId} style={{ background: '#2196f3', color: 'white', border: 'none', borderRadius: 4, padding: '7px 18px', fontSize: 15, cursor: adding ? 'not-allowed' : 'pointer' }}>
+          {adding ? "Adding..." : "Add"}
+        </button>
+      </div>
+      {uniqueRubrics.length === 0 && <div style={{ color: '#b71c1c', marginBottom: 8 }}>No pitch criteria found. Please create pitch criteria before adding a product.</div>}
+      {error && <div style={{ color: 'red', marginBottom: 8 }}>{error}</div>}
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {products.map(prod => (
+          <li key={prod._id} style={{ marginBottom: 8, display: 'flex', alignItems: 'center', gap: 10, background: '#fff', borderRadius: 5, padding: '6px 10px' }}>
+            <span
+              onClick={() => setSelectedProduct(prod)}
+              style={{ cursor: 'pointer', fontWeight: selectedProduct && selectedProduct._id === prod._id ? 600 : 400, color: selectedProduct && selectedProduct._id === prod._id ? '#e44210' : '#111', flex: 1 }}>
+              {prod.name}
+            </span>
+            <span style={{ fontSize: 13, color: prod.active ? '#388e3c' : '#b71c1c', fontWeight: 500, marginRight: 12 }}>
+              {prod.active ? 'Activated' : 'Not activated'}
+            </span>
+            <button
+              onClick={async () => {
+                setAdding(true);
+                setError("");
+                try {
+                  const res = await fetch("/api/products", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ name: prod.name, rubricId: prod.rubric?._id, active: !prod.active })
+                  });
+                  if (!res.ok) throw new Error("Failed to update product");
+                  onChange();
+                } catch (err) {
+                  setError("Could not update product. Try again.");
+                }
+                setAdding(false);
+              }}
+              style={{ background: prod.active ? '#f44336' : '#4caf50', color: 'white', border: 'none', borderRadius: 4, padding: '3px 12px', fontSize: 13, cursor: adding ? 'not-allowed' : 'pointer' }}
+            >
+              {prod.active ? 'Deactivate' : 'Activate'}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <RubricModal
+        open={rubricModalOpen}
+        initialName={modalInitialName}
+        initialQualities={modalInitialQualities}
+        rubricId={modalRubricId}
+        onClose={() => setRubricModalOpen(false)}
+        onSave={rubric => {
+          setRubricModalOpen(false);
+          if (modalRubricId) {
+            // Edited existing criteria
+            setSelectedProduct(p => p && p.rubric && p.rubric._id === rubric._id ? { ...p, rubric } : p);
+            onChange();
+          } else {
+            // Added new criteria for product creation
+            setSelectedRubricId(rubric._id);
+            setRubrics(old => [...old, rubric]);
+          }
+        }}
+      />
+      {/* Show criteria list for selected product */}
+      {selectedProduct && selectedProduct.rubric && (
+        <div style={{ background: '#fff', padding: '16px', borderRadius: 8, marginTop: 20 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <h3 style={{ marginTop: 0 }}>Criteria for {selectedProduct.name}</h3>
+            <button
+              onClick={() => {
+                // Open modal to edit existing criteria
+                setModalInitialName(selectedProduct.rubric.name);
+                setModalInitialQualities(selectedProduct.rubric.qualities || []);
+                setModalRubricId(selectedProduct.rubric._id);
+                setRubricModalOpen(true);
+              }}
+              style={{ background: '#ff9800', color: 'white', border: 'none', borderRadius: 4, padding: '6px 12px', cursor: 'pointer' }}
+            >
+              Edit Criteria
+            </button>
+          </div>
+          <ul style={{ listStyle: 'disc', paddingLeft: 20 }}>
+            {selectedProduct.rubric.qualities && selectedProduct.rubric.qualities.map((q, idx) => (
+              <li key={idx} style={{ marginBottom: 8 }}>
+                <strong>{q.name}</strong>: {q.description}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/admin/RubricModal.js
+++ b/frontend/src/admin/RubricModal.js
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+
+export default function RubricModal({ open, onClose, onSave, initialName = '', initialQualities = [], rubricId = null }) {
+  const [name, setName] = useState(initialName);
+  const [qualities, setQualities] = useState(initialQualities.length ? initialQualities : [{ name: "", description: "" }]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  if (!open) return null;
+
+  const handleQualityChange = (i, field, value) => {
+    setQualities(qs =>
+      qs.map((q, idx) => (idx === i ? { ...q, [field]: value } : q))
+    );
+  };
+  const handleAddQuality = () => {
+    setQualities(qs => [...qs, { name: "", description: "" }]);
+  };
+  const handleRemoveQuality = i => {
+    setQualities(qs => qs.filter((_, idx) => idx !== i));
+  };
+  const handleSave = async () => {
+    if (!name.trim() || qualities.some(q => !q.name.trim())) {
+      setError("Pitch criteria name and all qualities are required.");
+      return;
+    }
+    setSaving(true);
+    setError("");
+    try {
+      // Prepare payload; include rubricId when editing existing
+      let body = { name, qualities };
+      if (rubricId) {
+        body.rubricId = rubricId;
+      }
+      const res = await fetch("/api/rubric", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+      });
+      if (!res.ok) throw new Error("Failed to save pitch criteria");
+      const rubric = await res.json();
+      onSave(rubric);
+    } catch (err) {
+      setError("Could not save pitch criteria. Try again.");
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div style={{ position: "fixed", top: 0, left: 0, width: "100vw", height: "100vh", background: "rgba(0,0,0,0.35)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ background: "#fff", borderRadius: 8, padding: 28, minWidth: 410, maxWidth: 600, boxShadow: "0 2px 24px #0002" }}>
+        <h2 style={{ marginTop: 0 }}>Add New Pitch Criteria</h2>
+        <div style={{ marginBottom: 16 }}>
+          <input
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Pitch criteria name"
+            style={{ width: "100%", fontSize: 16, padding: 7, borderRadius: 4, border: '1px solid #bbb', marginBottom: 10 }}
+          />
+          <div style={{ fontWeight: 500, marginBottom: 6 }}>Qualities to Rate</div>
+          {qualities.map((q, i) => (
+            <div key={i} style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+              <input
+                value={q.name}
+                onChange={e => handleQualityChange(i, "name", e.target.value)}
+                placeholder="Quality name"
+                style={{ flex: 2, fontSize: 15, padding: 5, borderRadius: 4, border: '1px solid #bbb' }}
+              />
+              <input
+                value={q.description}
+                onChange={e => handleQualityChange(i, "description", e.target.value)}
+                placeholder="Description"
+                style={{ flex: 4, fontSize: 15, padding: 5, borderRadius: 4, border: '1px solid #bbb' }}
+              />
+              <button type="button" onClick={() => handleRemoveQuality(i)} style={{ background: '#f44336', color: 'white', border: 'none', borderRadius: 4, padding: '3px 10px', fontSize: 14, cursor: 'pointer' }}>Remove</button>
+            </div>
+          ))}
+          <button type="button" onClick={handleAddQuality} style={{ background: '#2196f3', color: 'white', border: 'none', borderRadius: 4, padding: '6px 18px', fontSize: 15, marginTop: 6, cursor: 'pointer' }}>Add Quality</button>
+        </div>
+        {error && <div style={{ color: 'red', marginBottom: 8 }}>{error}</div>}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 12 }}>
+          <button onClick={onClose} style={{ background: '#eee', color: '#222', border: 'none', borderRadius: 4, padding: '7px 18px', fontSize: 15 }}>Cancel</button>
+          <button onClick={handleSave} disabled={saving} style={{ background: '#4caf50', color: 'white', border: 'none', borderRadius: 4, padding: '7px 18px', fontSize: 15, cursor: saving ? 'not-allowed' : 'pointer' }}>{saving ? "Saving..." : "Save Pitch Criteria"}</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add login screen to choose admin or user role
- route admin panel under `/admin` and user UI under root using stored role
- integrate former admin components into main frontend

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a9fb1f7de8832dbfa6ae8b50ff629c